### PR TITLE
Add haptic feedback patterns across reading-plan interactions

### DIFF
--- a/src/components/date-navigation.tsx
+++ b/src/components/date-navigation.tsx
@@ -1,32 +1,57 @@
-"use client"
+"use client";
 
-import React from 'react'
-import { usePlan } from '@/context/PlanProvider'
-import { Button } from '@/components/ui/button'
-import { useTranslations } from 'next-intl'
+import { usePlan } from "@/context/PlanProvider";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
+import { haptic, hapticNavigate } from "@/lib/haptics";
 
 export function DateNavigation() {
-  const { selections, indexForToday, selectedIndex, setSelectedIndex } = usePlan()
-  const t = useTranslations('app')
+  const { selections, indexForToday, selectedIndex, setSelectedIndex } = usePlan();
+  const t = useTranslations("app");
 
-  const isFirst = selectedIndex === 0
-  const isLast = selectedIndex === selections.length - 1
+  const isFirst = selectedIndex === 0;
+  const isLast = selectedIndex === selections.length - 1;
 
   return (
     <div className="w-full max-w-md flex flex-col items-center gap-2">
       <div className="flex w-full items-center gap-2">
-        <Button disabled={isFirst} onClick={() => setSelectedIndex(Math.max(0, selectedIndex - 1))} variant="outline">←</Button>
+        <Button
+          disabled={isFirst}
+          onClick={() => {
+            hapticNavigate("prev");
+            setSelectedIndex(Math.max(0, selectedIndex - 1));
+          }}
+          variant="outline"
+        >
+          ←
+        </Button>
         <div className="flex-1 text-center text-sm text-muted-foreground">
-          {t('dateLabel', { daysFromToday: selectedIndex - indexForToday })}
+          {t("dateLabel", { daysFromToday: selectedIndex - indexForToday })}
         </div>
-        <Button disabled={isLast} onClick={() => setSelectedIndex(Math.min(selections.length - 1, selectedIndex + 1))} variant="outline">→</Button>
+        <Button
+          disabled={isLast}
+          onClick={() => {
+            hapticNavigate("next");
+            setSelectedIndex(Math.min(selections.length - 1, selectedIndex + 1));
+          }}
+          variant="outline"
+        >
+          →
+        </Button>
       </div>
       {selectedIndex !== indexForToday ? (
-        <Button onClick={() => setSelectedIndex(indexForToday)} variant="secondary">{t('today')}</Button>
+        <Button
+          onClick={() => {
+            haptic("success");
+            setSelectedIndex(indexForToday);
+          }}
+          variant="secondary"
+        >
+          {t("today")}
+        </Button>
       ) : (
         <div className="h-9" />
       )}
     </div>
-  )
+  );
 }
-

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "./ui/label";
 import { Input } from "./ui/input";
+import { haptic, hapticToggle } from "@/lib/haptics";
 
 export function Onboarding() {
   const t = useTranslations("onboarding");
@@ -27,7 +28,13 @@ export function Onboarding() {
         <div className="text-sm text-muted-foreground">{t("intro")}</div>
         <div className="flex items-center justify-between">
           <div className="text-sm font-normal">{t("selfPaced")}</div>
-          <Switch checked={isSelfPaced} onCheckedChange={setSelfPaced} />
+          <Switch
+            checked={isSelfPaced}
+            onCheckedChange={(checked) => {
+              hapticToggle(checked);
+              setSelfPaced(checked);
+            }}
+          />
         </div>
         {!isSelfPaced && (
           <div className="flex items-center justify-between gap-4">
@@ -38,12 +45,22 @@ export function Onboarding() {
               id="startDate"
               type="date"
               className="w-auto"
-              onChange={(e) => changeStartDate(new Date(e.target.value))}
+              onChange={(e) => {
+                haptic("soft");
+                changeStartDate(new Date(e.target.value));
+              }}
             />
           </div>
         )}
         <div className="flex justify-end">
-          <Button onClick={() => setOnboarded(true)}>{t("next")}</Button>
+          <Button
+            onClick={() => {
+              haptic("success");
+              setOnboarded(true);
+            }}
+          >
+            {t("next")}
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/components/reading-selection.tsx
+++ b/src/components/reading-selection.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
 import { splitPassage } from "@/lib/planConstants";
+import { hapticToggle } from "@/lib/haptics";
 
 export function ReadingSelection() {
   const { getSelection, hasRead, toggleRead, selectedIndex } = usePlan();
@@ -42,7 +43,10 @@ export function ReadingSelection() {
         return (
           <Button
             key={id}
-            onClick={() => toggleRead(desc, id)}
+            onClick={() => {
+              hapticToggle(!read);
+              toggleRead(desc, id);
+            }}
             variant={read ? "secondary" : "default"}
             className="justify-start h-16 rounded-full bg-accent text-accent-foreground hover:bg-accent/80"
           >

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -19,6 +19,7 @@ import { ThemeToggle } from "./theme-toggle";
 import { useSettings } from "@/context/SettingsContext";
 import { formatDateInput } from "@/lib/dateUtils";
 import { locales, type Locale } from "@/lib/i18n";
+import { haptic, hapticToggle } from "@/lib/haptics";
 import {
   Dropdown,
   DropdownTrigger,
@@ -43,6 +44,7 @@ export function SettingsDialog() {
   const handleLanguageChange = (newLocale: string) => {
     if (newLocale !== currentLocale) {
       // Set the locale cookie and redirect
+      haptic("success");
       document.cookie = `NEXT_LOCALE=${newLocale}; path=/; max-age=31536000`;
       router.push(`/${newLocale}`);
     }
@@ -87,7 +89,13 @@ export function SettingsDialog() {
             </div>
             <div className="flex items-center justify-between">
               <div className="text-md font-normal">{t("selfPaced")}</div>
-              <Switch checked={isSelfPaced} onCheckedChange={setSelfPaced} />
+              <Switch
+                checked={isSelfPaced}
+                onCheckedChange={(checked) => {
+                  hapticToggle(checked);
+                  setSelfPaced(checked);
+                }}
+              />
             </div>
             {!isSelfPaced && (
               <div className="flex items-center justify-between gap-4">
@@ -99,7 +107,10 @@ export function SettingsDialog() {
                   type="date"
                   className="w-auto"
                   value={formatDateInput(startDate)}
-                  onChange={(e) => changeStartDate(new Date(e.target.value))}
+                  onChange={(e) => {
+                    haptic("soft");
+                    changeStartDate(new Date(e.target.value));
+                  }}
                 />
               </div>
             )}
@@ -107,7 +118,10 @@ export function SettingsDialog() {
               {!confirmReset ? (
                 <Button
                   variant="destructive"
-                  onClick={() => setConfirmReset(true)}
+                  onClick={() => {
+                    haptic("warning");
+                    setConfirmReset(true);
+                  }}
                 >
                   {t("reset")}
                 </Button>
@@ -119,13 +133,17 @@ export function SettingsDialog() {
                   <div className="flex gap-2">
                     <Button
                       variant="outline"
-                      onClick={() => setConfirmReset(false)}
+                      onClick={() => {
+                        haptic("soft");
+                        setConfirmReset(false);
+                      }}
                     >
                       {t("cancel")}
                     </Button>
                     <Button
                       variant="destructive"
                       onClick={() => {
+                        haptic("warning");
                         changeStartDate(new Date());
                         setConfirmReset(false);
                       }}
@@ -138,7 +156,14 @@ export function SettingsDialog() {
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={closeSettings}>{t("close")}</Button>
+            <Button
+              onClick={() => {
+                haptic("soft");
+                closeSettings();
+              }}
+            >
+              {t("close")}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -4,6 +4,7 @@ import { Moon, Sun, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
+import { haptic, hapticToggle } from "@/lib/haptics";
 
 export function ThemeToggle() {
   const [mounted, setMounted] = useState(false);
@@ -42,6 +43,12 @@ export function ThemeToggle() {
 
     const newTheme =
       theme === "light" ? "dark" : theme === "dark" ? "system" : "light";
+
+    if (newTheme === "system") {
+      haptic("soft");
+    } else {
+      hapticToggle(newTheme === "dark");
+    }
     setTheme(newTheme);
 
     if (typeof window !== "undefined") {

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,44 @@
+"use client";
+
+export type HapticType =
+  | "tap"
+  | "soft"
+  | "success"
+  | "warning"
+  | "toggle-on"
+  | "toggle-off"
+  | "navigate-forward"
+  | "navigate-back";
+
+const PATTERNS: Record<HapticType, number | number[]> = {
+  tap: 12,
+  soft: 6,
+  success: [16, 30, 24],
+  warning: [30, 60, 30],
+  "toggle-on": [10, 20, 14],
+  "toggle-off": [20, 24, 8],
+  "navigate-forward": [8, 12, 8],
+  "navigate-back": [8, 18, 12],
+};
+
+function canVibrate() {
+  if (typeof window === "undefined") return false;
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+    return false;
+  }
+
+  return typeof navigator !== "undefined" && "vibrate" in navigator;
+}
+
+export function haptic(type: HapticType = "tap") {
+  if (!canVibrate()) return;
+  navigator.vibrate(PATTERNS[type]);
+}
+
+export function hapticToggle(nextValue: boolean) {
+  haptic(nextValue ? "toggle-on" : "toggle-off");
+}
+
+export function hapticNavigate(direction: "next" | "prev") {
+  haptic(direction === "next" ? "navigate-forward" : "navigate-back");
+}


### PR DESCRIPTION
### Motivation
- Provide tactile feedback to make common reading-plan interactions feel more responsive and satisfying on capable devices while respecting accessibility preferences.
- Implement a lightweight, dependency-free approach so feedback works without pulling an external package and only runs when vibration is supported and `prefers-reduced-motion` is not set.

### Description
- Add a client-side haptics utility at `src/lib/haptics.ts` that exposes `haptic`, `hapticToggle`, and `hapticNavigate` with predefined vibration patterns for taps, soft notifications, success, warning, toggles, and directional navigation.
- Wire toggle feedback into passage completion actions in `src/components/reading-selection.tsx` so toggling a passage produces on/off feedback.
- Add navigation and jump-to-today feedback in `src/components/date-navigation.tsx` using directional and success patterns respectively.
- Add onboarding feedback for the self-paced switch, start-date input, and continue button in `src/components/onboarding.tsx` to reinforce choices.
- Add settings feedback for language changes, self-paced toggle, start-date edits, reset confirmation/cancel/execute, and dialog close in `src/components/settings-dialog.tsx` to make settings feel tactile.
- Add theme-cycle feedback in `src/components/theme-toggle.tsx` with distinct patterns for toggling dark/light and switching to system mode.

### Testing
- Ran lint with `npm run lint` which completed without errors (warnings only) and did not introduce lint failures.
- Ran unit tests with `npm test -- --runInBand` and all suites passed: `8` test suites and `40` tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a89821d124832b8831c4e5b29e8568)