### PR TITLE
Add integrated PostHog feedback survey

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -39,6 +39,24 @@
     "cancel": "Abbrechen",
     "close": "Schließen"
   },
+  "feedbackSurvey": {
+    "trigger": "Feedback",
+    "loading": "Feedback-Formular wird geladen...",
+    "title": "Produktfeedback",
+    "description": "Teile Ideen, Fehler oder fehlende Funktionen mit uns.",
+    "categoryQuestion": "Was möchtest du mitteilen?",
+    "detailsQuestion": "Erzähl uns mehr",
+    "detailsDescription": "Beschreibe deinen Vorschlag oder dein Problem mit so vielen Details, wie du möchtest.",
+    "placeholder": "Schreib hier los...",
+    "submit": "Senden",
+    "thankYouTitle": "Danke für dein Feedback!",
+    "thankYouDescription": "Deine Antwort wurde gespeichert.",
+    "choices": {
+      "suggestFeature": "Neue Funktion vorschlagen",
+      "reportBroken": "Einen Fehler melden",
+      "missing": "Etwas fehlt"
+    }
+  },
   "onboarding": {
     "title": "Willkommen",
     "intro": "Der tägliche Bibelleseplan von Robert Murray M'Cheyne führt Leserinnen und Leser einmal durch das Alte Testament und zweimal pro Jahr durch das Neue Testament und die Psalmen.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,6 +39,24 @@
     "close": "Close",
     "german": "German"
   },
+  "feedbackSurvey": {
+    "trigger": "Feedback",
+    "loading": "Loading feedback form...",
+    "title": "Product feedback",
+    "description": "Share ideas, bugs, or missing functionality.",
+    "categoryQuestion": "What would you like to share?",
+    "detailsQuestion": "Tell us more",
+    "detailsDescription": "Please describe your suggestion or issue in as much detail as you'd like.",
+    "placeholder": "Start typing...",
+    "submit": "Submit",
+    "thankYouTitle": "Thank you for your feedback!",
+    "thankYouDescription": "Your response has been recorded.",
+    "choices": {
+      "suggestFeature": "Suggest a new feature",
+      "reportBroken": "Report something broken",
+      "missing": "Something is missing"
+    }
+  },
   "onboarding": {
     "title": "Welcome",
     "intro": "Robert Murray M'Cheyne's daily Bible reading plan guides readers through the Old Testament once and the New Testament and Psalms twice per year.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -39,6 +39,24 @@
     "close": "Cerrar",
     "german": "Alemán"
   },
+  "feedbackSurvey": {
+    "trigger": "Comentarios",
+    "loading": "Cargando formulario de comentarios...",
+    "title": "Comentarios del producto",
+    "description": "Comparte ideas, errores o funciones que faltan.",
+    "categoryQuestion": "¿Qué te gustaría compartir?",
+    "detailsQuestion": "Cuéntanos más",
+    "detailsDescription": "Describe tu sugerencia o problema con todo el detalle que quieras.",
+    "placeholder": "Empieza a escribir...",
+    "submit": "Enviar",
+    "thankYouTitle": "¡Gracias por tus comentarios!",
+    "thankYouDescription": "Tu respuesta ha sido registrada.",
+    "choices": {
+      "suggestFeature": "Sugerir una nueva función",
+      "reportBroken": "Reportar algo roto",
+      "missing": "Falta algo"
+    }
+  },
   "onboarding": {
     "title": "Bienvenido",
     "intro": "El plan de lectura bíblica diaria de Robert Murray M'Cheyne guía a los lectores a través del Antiguo Testamento una vez y del Nuevo Testamento y los Salmos dos veces al año.",

--- a/src/components/PostHogProvider.test.tsx
+++ b/src/components/PostHogProvider.test.tsx
@@ -16,10 +16,16 @@ jest.mock('posthog-js/react', () => ({
 
 describe('PostHogProvider', () => {
   const originalLang = document.documentElement.lang;
+  const originalDisableLocalOptOut = process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT;
+  const mockPhClient = {
+    opt_out_capturing: jest.fn(),
+    opt_in_capturing: jest.fn(),
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    delete process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT;
     // Mock document.documentElement.lang
     Object.defineProperty(document.documentElement, 'lang', {
       value: 'en',
@@ -34,8 +40,19 @@ describe('PostHogProvider', () => {
       configurable: true,
       writable: true,
     });
+    if (originalDisableLocalOptOut === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT = originalDisableLocalOptOut;
+    }
     jest.useRealTimers();
   });
+
+  function getLoadedCallback() {
+    const initMock = posthog.init as jest.Mock;
+    const initConfig = initMock.mock.calls[0]?.[1];
+    return initConfig?.loaded as ((ph: typeof mockPhClient) => void) | undefined;
+  }
 
   it('sets first_seen_at property if not present in localStorage', () => {
     const mockDate = new Date('2023-01-01T00:00:00.000Z');
@@ -130,5 +147,34 @@ describe('PostHogProvider', () => {
     expect(posthog.setPersonProperties).toHaveBeenCalledWith({
       language: 'de',
     });
+  });
+
+  it('opts out of PostHog on localhost by default', () => {
+    render(
+      <PostHogProvider locale="en">
+        <div>Test Child</div>
+      </PostHogProvider>
+    );
+
+    const loaded = getLoadedCallback();
+    loaded?.(mockPhClient);
+
+    expect(mockPhClient.opt_out_capturing).toHaveBeenCalled();
+  });
+
+  it('keeps PostHog enabled locally when local opt-out is disabled via env var', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT = 'true';
+
+    render(
+      <PostHogProvider locale="en">
+        <div>Test Child</div>
+      </PostHogProvider>
+    );
+
+    const loaded = getLoadedCallback();
+    loaded?.(mockPhClient);
+
+    expect(mockPhClient.opt_out_capturing).not.toHaveBeenCalled();
+    expect(mockPhClient.opt_in_capturing).toHaveBeenCalled();
   });
 });

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -4,6 +4,24 @@ import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider } from 'posthog-js/react';
 import { useEffect } from 'react';
 
+function shouldOptOutLocally(hostname: string) {
+  const disableLocalOptOut = process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT === 'true';
+
+  if (disableLocalOptOut) {
+    return false;
+  }
+
+  return (
+    hostname.includes('vercel.app') || hostname.includes('localhost') || hostname.includes('.local')
+  );
+}
+
+function isLocalTestingHost(hostname: string) {
+  return (
+    hostname.includes('vercel.app') || hostname.includes('localhost') || hostname.includes('.local')
+  );
+}
+
 export function PostHogProvider({
   children,
   locale,
@@ -19,12 +37,14 @@ export function PostHogProvider({
       capture_exceptions: true,
       debug: process.env.NODE_ENV === 'development',
       loaded: (ph) => {
-        if (
-          window.location.hostname.includes('vercel.app') ||
-          window.location.hostname.includes('localhost') ||
-          window.location.hostname.includes('.local')
-        ) {
+        const { hostname } = window.location;
+        const disableLocalOptOut = process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT === 'true';
+
+        if (shouldOptOutLocally(hostname)) {
           ph.opt_out_capturing();
+        } else if (disableLocalOptOut && isLocalTestingHost(hostname)) {
+          // Re-enable PostHog if this browser was previously opted out during local development.
+          ph.opt_in_capturing();
         }
       },
     });

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -4,6 +4,12 @@ import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider } from 'posthog-js/react';
 import { useEffect } from 'react';
 
+function isLocalLikeHost(hostname: string) {
+  return (
+    hostname.includes('vercel.app') || hostname.includes('localhost') || hostname.includes('.local')
+  );
+}
+
 function shouldOptOutLocally(hostname: string) {
   const disableLocalOptOut = process.env.NEXT_PUBLIC_POSTHOG_DISABLE_LOCAL_OPT_OUT === 'true';
 
@@ -11,15 +17,7 @@ function shouldOptOutLocally(hostname: string) {
     return false;
   }
 
-  return (
-    hostname.includes('vercel.app') || hostname.includes('localhost') || hostname.includes('.local')
-  );
-}
-
-function isLocalTestingHost(hostname: string) {
-  return (
-    hostname.includes('vercel.app') || hostname.includes('localhost') || hostname.includes('.local')
-  );
+  return isLocalLikeHost(hostname);
 }
 
 export function PostHogProvider({
@@ -42,7 +40,7 @@ export function PostHogProvider({
 
         if (shouldOptOutLocally(hostname)) {
           ph.opt_out_capturing();
-        } else if (disableLocalOptOut && isLocalTestingHost(hostname)) {
+        } else if (disableLocalOptOut && isLocalLikeHost(hostname)) {
           // Re-enable PostHog if this browser was previously opted out during local development.
           ph.opt_in_capturing();
         }

--- a/src/components/client-providers.tsx
+++ b/src/components/client-providers.tsx
@@ -6,10 +6,11 @@ import { Analytics } from '@vercel/analytics/react';
 import { Header } from './header';
 import { SettingsProvider, useSettings } from '@/context/SettingsContext';
 import { PostHogProvider } from './PostHogProvider';
+import { FeedbackSurvey } from './feedback-survey';
 
 function HeaderWithSettings() {
   const { openSettings } = useSettings();
-  return <Header onSettingsClick={openSettings} />;
+  return <Header onSettingsClick={openSettings} feedbackAction={<FeedbackSurvey />} />;
 }
 
 function FooterQuote() {

--- a/src/components/feedback-survey.test.tsx
+++ b/src/components/feedback-survey.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedbackSurvey } from './feedback-survey';
+
+const mockPostHog = {
+  getActiveMatchingSurveys: jest.fn(),
+  getSurveys: jest.fn(),
+  capture: jest.fn(),
+};
+
+const survey = {
+  id: '019cb856-10c4-0000-71c8-b1709668c410',
+  name: 'Product feedback',
+  description: 'Share ideas, bugs, or missing functionality.',
+  appearance: {
+    widgetLabel: 'Feedback',
+    placeholder: 'Start typing...',
+    thankYouMessageHeader: 'Thank you for your feedback!',
+  },
+  questions: [
+    {
+      id: '5843b1d1-6105-4e15-bae3-bb260c925e44',
+      type: 'single_choice',
+      question: 'What would you like to share?',
+      choices: ['Suggest a new feature', 'Report something broken', 'Something is missing'],
+    },
+    {
+      id: '6d80331b-a099-496e-8248-f1f1589f334b',
+      type: 'open',
+      question: 'Tell us more',
+      description: 'Please describe your suggestion or issue in as much detail as you would like.',
+      buttonText: 'Submit',
+    },
+  ],
+};
+
+jest.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => {
+    const translations: Record<string, Record<string, string>> = {
+      settings: {
+        cancel: 'Cancel',
+        close: 'Close',
+      },
+      feedbackSurvey: {
+        trigger: 'Feedback',
+        title: 'Product feedback',
+        description: 'Share ideas, bugs, or missing functionality.',
+        categoryQuestion: 'What would you like to share?',
+        detailsQuestion: 'Tell us more',
+        detailsDescription:
+          'Please describe your suggestion or issue in as much detail as you would like.',
+        placeholder: 'Start typing...',
+        submit: 'Submit',
+        thankYouTitle: 'Thank you for your feedback!',
+        thankYouDescription: 'Your response has been recorded.',
+        'choices.suggestFeature': 'Suggest a new feature',
+        'choices.reportBroken': 'Report something broken',
+        'choices.missing': 'Something is missing',
+      },
+    };
+
+    return (key: string) => translations[namespace]?.[key] ?? key;
+  },
+}));
+
+jest.mock('posthog-js/react', () => ({
+  usePostHog: () => mockPostHog,
+}));
+
+describe('FeedbackSurvey', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render when the survey is not active for the user', async () => {
+    mockPostHog.getActiveMatchingSurveys.mockImplementation((callback: (surveys: []) => void) => {
+      callback([]);
+    });
+
+    render(<FeedbackSurvey />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Feedback' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('captures survey events and responses from the custom UI', async () => {
+    mockPostHog.getActiveMatchingSurveys.mockImplementation(
+      (callback: (surveys: (typeof survey)[]) => void) => {
+        callback([survey]);
+      }
+    );
+
+    render(<FeedbackSurvey />);
+
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Feedback' }));
+
+    expect(mockPostHog.capture).toHaveBeenCalledWith('survey shown', {
+      $survey_id: survey.id,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Report something broken' }));
+    await user.type(screen.getByLabelText('Tell us more'), 'The language switch needs a refresh.');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(mockPostHog.capture).toHaveBeenCalledWith('survey sent', {
+      $survey_id: survey.id,
+      ['$survey_response_5843b1d1-6105-4e15-bae3-bb260c925e44']: 'Report something broken',
+      ['$survey_response_6d80331b-a099-496e-8248-f1f1589f334b']:
+        'The language switch needs a refresh.',
+    });
+
+    expect(await screen.findByText('Thank you for your feedback!')).toBeInTheDocument();
+  });
+});

--- a/src/components/feedback-survey.tsx
+++ b/src/components/feedback-survey.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MessageSquareMore } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { usePostHog } from 'posthog-js/react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+const PRODUCT_FEEDBACK_SURVEY_ID = '019cb856-10c4-0000-71c8-b1709668c410';
+
+type SurveyQuestion = {
+  id?: string;
+  type: 'open' | 'single_choice' | string;
+  question: string;
+  description?: string | null;
+  choices?: string[];
+  buttonText?: string;
+};
+
+type FeedbackSurveyConfig = {
+  id: string;
+  name: string;
+  description: string;
+  questions: SurveyQuestion[];
+  appearance?: {
+    widgetLabel?: string;
+    placeholder?: string;
+    thankYouMessageHeader?: string;
+    thankYouMessageDescription?: string;
+    displayThankYouMessage?: boolean;
+  } | null;
+};
+
+function isFeedbackSurvey(survey: { id?: string }): survey is FeedbackSurveyConfig {
+  return survey.id === PRODUCT_FEEDBACK_SURVEY_ID;
+}
+
+function getLocalizedChoiceLabel(
+  choice: string,
+  t: ReturnType<typeof useTranslations<'feedbackSurvey'>>
+) {
+  switch (choice) {
+    case 'Suggest a new feature':
+      return t('choices.suggestFeature');
+    case 'Report something broken':
+      return t('choices.reportBroken');
+    case 'Something is missing':
+      return t('choices.missing');
+    default:
+      return choice;
+  }
+}
+
+export function FeedbackSurvey() {
+  const posthog = usePostHog();
+  const t = useTranslations('settings');
+  const surveyT = useTranslations('feedbackSurvey');
+  const [survey, setSurvey] = useState<FeedbackSurveyConfig | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedChoice, setSelectedChoice] = useState('');
+  const [details, setDetails] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const hasTrackedShownRef = useRef(false);
+
+  const loadSurvey = useCallback(
+    (forceReload = false) => {
+      if (!posthog) {
+        return;
+      }
+
+      posthog.getActiveMatchingSurveys((surveys) => {
+        const matchingSurvey = surveys.find(isFeedbackSurvey) ?? null;
+        setSurvey(matchingSurvey);
+      }, forceReload);
+    },
+    [posthog]
+  );
+
+  useEffect(() => {
+    loadSurvey();
+  }, [loadSurvey]);
+
+  const categoryQuestion = useMemo(
+    () => survey?.questions.find((question) => question.type === 'single_choice'),
+    [survey]
+  );
+
+  const detailsQuestion = useMemo(
+    () => survey?.questions.find((question) => question.type === 'open'),
+    [survey]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      hasTrackedShownRef.current = false;
+      return;
+    }
+
+    if (!posthog || !survey || isSubmitted || hasTrackedShownRef.current) {
+      return;
+    }
+
+    posthog.capture('survey shown', {
+      $survey_id: survey.id,
+    });
+    hasTrackedShownRef.current = true;
+  }, [isOpen, isSubmitted, posthog, survey]);
+
+  const resetState = useCallback(() => {
+    setSelectedChoice('');
+    setDetails('');
+    setIsSubmitted(false);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setIsOpen(nextOpen);
+
+      if (!nextOpen) {
+        if (isSubmitted) {
+          setSurvey(null);
+        }
+
+        // This dialog is intentionally on-demand, so closing it should not permanently
+        // dismiss the survey for the user before they decide to submit.
+        resetState();
+      }
+    },
+    [isSubmitted, resetState]
+  );
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (
+        !posthog ||
+        !survey ||
+        !categoryQuestion?.id ||
+        !detailsQuestion?.id ||
+        !selectedChoice ||
+        !details.trim()
+      ) {
+        return;
+      }
+
+      posthog.capture('survey sent', {
+        $survey_id: survey.id,
+        [`$survey_response_${categoryQuestion.id}`]: selectedChoice,
+        [`$survey_response_${detailsQuestion.id}`]: details.trim(),
+      });
+
+      setIsSubmitted(true);
+    },
+    [categoryQuestion?.id, details, detailsQuestion?.id, posthog, selectedChoice, survey]
+  );
+
+  const triggerLabel = surveyT('trigger');
+  const canRenderSurveyForm = !!survey && !!categoryQuestion?.choices?.length && !!detailsQuestion;
+
+  if (!canRenderSurveyForm) {
+    return null;
+  }
+
+  const canSubmit = selectedChoice.length > 0 && details.trim().length > 0;
+  const activeSurvey = survey;
+  const categoryChoices = categoryQuestion.choices ?? [];
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={() => setIsOpen(true)}
+        aria-label={triggerLabel}
+      >
+        <MessageSquareMore className="h-4 w-4" />
+        <span className="hidden sm:inline">{triggerLabel}</span>
+      </Button>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          {isSubmitted && activeSurvey ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>{surveyT('thankYouTitle')}</DialogTitle>
+                <DialogDescription>
+                  {activeSurvey.appearance?.thankYouMessageDescription ||
+                    surveyT('thankYouDescription')}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button onClick={() => handleOpenChange(false)}>{t('close')}</Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <DialogHeader>
+                <DialogTitle>{surveyT('title')}</DialogTitle>
+                <DialogDescription>{surveyT('description')}</DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-3">
+                <p className="text-sm font-medium">{surveyT('categoryQuestion')}</p>
+                <div className="grid gap-2">
+                  {categoryChoices.map((choice) => {
+                    const isSelected = selectedChoice === choice;
+
+                    return (
+                      <button
+                        key={choice}
+                        type="button"
+                        className={cn(
+                          'rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                          isSelected
+                            ? 'border-primary bg-primary/10 text-foreground'
+                            : 'border-border hover:bg-accent hover:text-accent-foreground'
+                        )}
+                        aria-pressed={isSelected}
+                        onClick={() => setSelectedChoice(choice)}
+                      >
+                        {getLocalizedChoiceLabel(choice, surveyT)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <label className="text-sm font-medium" htmlFor="feedback-details">
+                  {surveyT('detailsQuestion')}
+                </label>
+                <p className="text-sm text-muted-foreground">{surveyT('detailsDescription')}</p>
+                <Textarea
+                  id="feedback-details"
+                  value={details}
+                  onChange={(event) => setDetails(event.target.value)}
+                  placeholder={surveyT('placeholder')}
+                />
+              </div>
+
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                  {t('cancel')}
+                </Button>
+                <Button type="submit" disabled={!canSubmit}>
+                  {surveyT('submit')}
+                </Button>
+              </DialogFooter>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,8 +4,15 @@ import { BookOpen, Settings } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 
-export function Header({ onSettingsClick }: { onSettingsClick: () => void }) {
+export function Header({
+  onSettingsClick,
+  feedbackAction,
+}: {
+  onSettingsClick: () => void;
+  feedbackAction?: React.ReactNode;
+}) {
   const t = useTranslations('app');
+  const settingsT = useTranslations('settings');
 
   return (
     <div className="flex items-center justify-between w-full max-w-md">
@@ -16,9 +23,17 @@ export function Header({ onSettingsClick }: { onSettingsClick: () => void }) {
           <div className="text-sm font-semibold text-muted-foreground">{t('subtitle')}</div>
         </div>
       </div>
-      <Button variant="outline" size="icon" onClick={onSettingsClick}>
-        <Settings className="h-4 w-4" />
-      </Button>
+      <div className="flex items-center gap-2">
+        {feedbackAction}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onSettingsClick}
+          aria-label={settingsT('open')}
+        >
+          <Settings className="h-4 w-4" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';
+
+export { Textarea };


### PR DESCRIPTION
## Summary
- add a custom PostHog feedback survey entry point in the app header with localized UI for English, Spanish, and German
- submit survey lifecycle and response events back to PostHog while keeping the survey definition managed in PostHog itself
- make local PostHog testing configurable so survey behavior can be validated safely before launch

## Test plan
- [x] `npx jest "src/components/feedback-survey.test.tsx" "src/components/PostHogProvider.test.tsx" "src/components/client-providers.test.tsx" --runInBand`
- [x] `npm run lint -- --file src/components/feedback-survey.tsx --file src/components/feedback-survey.test.tsx --file src/components/PostHogProvider.tsx --file src/components/PostHogProvider.test.tsx --file src/components/client-providers.tsx --file src/components/header.tsx --file src/components/ui/textarea.tsx`
- [x] `npm run build`
- [x] manually verified the survey opens, submits, and respects app translations


Made with [Cursor](https://cursor.com)