### PR TITLE
Fix language cookie persistence across sessions

### DIFF
--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -14,7 +14,6 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { useTranslations, useLocale } from 'next-intl';
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { ThemeToggle } from './theme-toggle';
 import { useSettings } from '@/context/SettingsContext';
 import { formatDateInput } from '@/lib/dateUtils';
@@ -26,7 +25,6 @@ export function SettingsDialog() {
   const { isSelfPaced, setSelfPaced, startDate, changeStartDate } = usePlan();
   const { isOpen, closeSettings } = useSettings();
   const [confirmReset, setConfirmReset] = useState(false);
-  const router = useRouter();
   const currentLocale = useLocale();
 
   const localeLabelMap: Record<Locale, string> = {
@@ -39,7 +37,7 @@ export function SettingsDialog() {
     if (newLocale !== currentLocale) {
       // Set the locale cookie and redirect
       document.cookie = `NEXT_LOCALE=${newLocale}; path=/; max-age=31536000`;
-      router.push(`/${newLocale}`);
+      window.location.href = `/${newLocale}`;
     }
   };
 


### PR DESCRIPTION
This PR fixes an issue where the language selection was not persistent across browser sessions. 

The issue was caused by using `router.push` when changing the language. `router.push` triggers a soft navigation (RSC request), and it appears that during this soft navigation, the `NEXT_LOCALE` cookie was sometimes being overridden as a session cookie, losing its `max-age`. 

By changing `router.push` to `window.location.href`, we force a full page reload (hard navigation). This ensures that the newly set `NEXT_LOCALE` cookie with its proper `max-age` is correctly respected and persisted by the browser and subsequent server requests.

**Changes:**
- Updated `src/components/settings-dialog.tsx` to use `window.location.href = '/' + newLocale` instead of `router.push`.
- Removed the unused `useRouter` import and hook.

**Testing:**
- Verified via puppeteer scripts that the cookie now persists across browser restarts.
- Ran all existing unit tests, which passed successfully.

---
*PR created automatically by Jules for task [6664008990988130125](https://jules.google.com/task/6664008990988130125) started by @felipeS*